### PR TITLE
Implementing issue #39

### DIFF
--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/menu/GeneratePDF.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/menu/GeneratePDF.java
@@ -57,7 +57,7 @@ public final class GeneratePDF implements ActionListener {
             File v_overwriting = new File(file.toString() + ".pdf");
             while (v_overwriting.exists() && reply == JOptionPane.NO_OPTION) {
                 reply = JOptionPane.showConfirmDialog(null,
-                            "The selected file already exists. Do you want to overwrite it?",
+                            v_overwriting.toString() + " already exists. Do you want to overwrite it?",
                             "File already exists.",
                             JOptionPane.YES_NO_OPTION);
                 if (reply == JOptionPane.NO_OPTION) { //The user does not want to overwrite. Then select another name

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/menu/GeneratePDF.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/menu/GeneratePDF.java
@@ -8,6 +8,7 @@ package latexstudio.editor.menu;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
+import javax.swing.JOptionPane;
 import latexstudio.editor.ApplicationLogger;
 import latexstudio.editor.EditorTopComponent;
 import latexstudio.editor.TopComponentFactory;
@@ -44,18 +45,44 @@ public final class GeneratePDF implements ActionListener {
     @Override
     public void actionPerformed(ActionEvent e) {        
         File file = FileChooserService.getSelectedFile("pdf", "PDF files", DialogType.PDF, false);
+        int reply = JOptionPane.NO_OPTION;
         if (file != null) {
-            String filename = file.getName();
+            //When the user clicks a file, the Chooser shows "file.pdf", so we have to remove this ".pdf"
+            //Otherwise, pdflatex will create a "file.pdf.pdf"
+            if (file.toString().endsWith(".pdf")) {
+               file = new File(file.toString().substring(0, file.toString().length() - 4));
+            }
             
-            LOGGER.log("Invoking pdflatex");
-  
-            CommandLineExecutor.executeGeneratePDF(new CommandLineBuilder()
-                .withPathToSource(ApplicationUtils.getTempSourceFile())
-                .withOutputDirectory(file.getParentFile().getAbsolutePath())
-                .withJobname(filename)
-                .withWorkingFile(etc.getCurrentFile())
-                .withLatexPath(etc.getLatexPath())
-                .withLogger(new ApplicationLogger("pdflatex")));
+            //If the user only type "file", we have to check if "file.pdf" exists.
+            File v_overwriting = new File(file.toString() + ".pdf");
+            while (v_overwriting.exists() && reply == JOptionPane.NO_OPTION) {
+                reply = JOptionPane.showConfirmDialog(null,
+                            "The selected file already exists. Do you want to overwrite it?",
+                            "File already exists.",
+                            JOptionPane.YES_NO_OPTION);
+                if (reply == JOptionPane.NO_OPTION) { //The user does not want to overwrite. Then select another name
+                    file = FileChooserService.getSelectedFile("pdf", "PDF files", DialogType.PDF, false);
+                    if (file != null) {
+                        if (file.toString().endsWith(".pdf")) {
+                            file = new File(file.toString().substring(0, file.toString().length() - 4));
+                         }
+                        v_overwriting = new File(file.toString() + ".pdf");
+                    }
+                    else return;
+                }
+            }
         }
+        if (file == null) return;
+        String filename = file.getName();
+
+        LOGGER.log("Invoking pdflatex");
+
+        CommandLineExecutor.executeGeneratePDF(new CommandLineBuilder()
+            .withPathToSource(ApplicationUtils.getTempSourceFile())
+            .withOutputDirectory(file.getParentFile().getAbsolutePath())
+            .withJobname(filename)
+            .withWorkingFile(etc.getCurrentFile())
+            .withLatexPath(etc.getLatexPath())
+            .withLogger(new ApplicationLogger("pdflatex")));  
     }
 }


### PR DESCRIPTION
The code may look large, but I have made some fixies that had not been seen in #39
Before this commit, if the user click GENERATE, and then CLICK on a pdf file, the Chooser would select "file.pdf". After that, pdflatex would generate the output onto "file.pdf.pdf", instead of overwriting the clicked file. So I fixed this. I remove the ".pdf" if the selected file has this name.

Besides, I implemented the #39 issue. If the output file already exists, the program notify the user and asks to overwrite the file.