### PR TITLE
Feature implemented: Remember last path

### DIFF
--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/files/FileChooserService.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/files/FileChooserService.java
@@ -9,6 +9,8 @@ import java.io.File;
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.swing.JOptionPane;
+import latexstudio.editor.settings.ApplicationSettings;
+import latexstudio.editor.settings.SettingsService;
 
 /**
  * This is a simple util class, generating the file/directory chooser modals and
@@ -30,10 +32,21 @@ public final class FileChooserService {
         JFileChooser chooser = new JFileChooser();
         chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
 
+        // retreiving last directory selected by the user
+        String currentDirectory = SettingsService.loadApplicationSettings().getUserLastDir();
+        if(currentDirectory != null && currentDirectory.length() > 0) {
+            chooser.setCurrentDirectory(new File(currentDirectory));
+        }
+        
         int returnVal = chooser.showDialog(null, buttonText);
         if (returnVal == JFileChooser.APPROVE_OPTION) {
             File file = chooser.getSelectedFile();
-
+            
+            // storing last directory selected by the user
+            ApplicationSettings appSettings = SettingsService.loadApplicationSettings();
+            appSettings.setUserLastDir(file.getAbsolutePath());
+            SettingsService.saveApplicationSettings(appSettings);
+            
             return file;
         }
 
@@ -49,6 +62,11 @@ public final class FileChooserService {
         FileNameExtensionFilter filter = new FileNameExtensionFilter(description, extension);
         chooser.setFileFilter(filter);
 
+        String currentDirectory = SettingsService.loadApplicationSettings().getUserLastDir();
+        if(currentDirectory != null && currentDirectory.length() > 0) {
+            chooser.setCurrentDirectory(new File(currentDirectory));
+        }
+        
         int returnVal = 0;
         switch (type) {
             case SAVE:
@@ -73,6 +91,11 @@ public final class FileChooserService {
                 if (fixExtension && !filePath.endsWith("." + extension)) {
                     file = new File(filePath + "." + extension);
                 }
+                
+                // storing last directory selected by the user
+                ApplicationSettings appSettings = SettingsService.loadApplicationSettings();
+                appSettings.setUserLastDir(file.getParentFile().getAbsolutePath());
+                SettingsService.saveApplicationSettings(appSettings);
 
                 return file;
             }

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/settings/ApplicationSettings.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/settings/ApplicationSettings.java
@@ -14,6 +14,7 @@ import java.util.Properties;
 public class ApplicationSettings extends Properties {
     
     private static final String DROPBOX_TOKEN = "dropbox.token";
+    private static final String USER_LASTDIR = "user.lastdir";
     
     public void setDropboxToken(String token) {
         setProperty(DROPBOX_TOKEN, token);
@@ -21,5 +22,13 @@ public class ApplicationSettings extends Properties {
     
     public String getDropboxToken() {
         return getProperty(DROPBOX_TOKEN);
+    }
+    
+    public void setUserLastDir(String dir) {
+        setProperty(USER_LASTDIR, dir);
+    }
+    
+    public String getUserLastDir() {
+        return getProperty(USER_LASTDIR);
     }
 }


### PR DESCRIPTION
When a path is choosen one time, it is remembered for the next time so that the user could save time if he/she wants to save a new document in the same directory.
The feature was implemented on both getSelectedFile and getSelectedDirectory methods.

Now only with the changes related to the implementation.