### PR TITLE
Issue70

### DIFF
--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/DropboxRevisionsTopComponent.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/DropboxRevisionsTopComponent.java
@@ -152,7 +152,9 @@ public final class DropboxRevisionsTopComponent extends TopComponent {
                 outputStream = new FileOutputStream(outputFile);
                 client.getFile(entry.getPath(), entry.getRevision(), outputStream);
                 LOGGER.log("Loaded revision " + entry.getRevision() + " from Dropbox");
-            } catch (Throwable e) {
+            } catch (DbxException e) {
+                DbxUtil.showDbxAccessDeniedPrompt();
+            } catch (IOException e) {
                 Exceptions.printStackTrace(e);
             } finally {
                 IOUtils.closeQuietly(outputStream);
@@ -219,7 +221,7 @@ public final class DropboxRevisionsTopComponent extends TopComponent {
             try {
                 entries = client.getRevisions(path);
             } catch (DbxException ex) {
-                Exceptions.printStackTrace(ex);
+                DbxUtil.showDbxAccessDeniedPrompt();
             }
         }
 

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/DropboxRevisionsTopComponent.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/DropboxRevisionsTopComponent.java
@@ -215,10 +215,12 @@ public final class DropboxRevisionsTopComponent extends TopComponent {
         DbxClient client = DbxUtil.getDbxClient();
         List<DbxEntry.File> entries = null;
 
-        try {
-            entries = client.getRevisions(path);
-        } catch (DbxException ex) {
-            Exceptions.printStackTrace(ex);
+        if (path != null) {
+            try {
+                entries = client.getRevisions(path);
+            } catch (DbxException ex) {
+                Exceptions.printStackTrace(ex);
+            }
         }
 
         dlm.clear();
@@ -233,9 +235,11 @@ public final class DropboxRevisionsTopComponent extends TopComponent {
         model.addColumn(FILE_SIZE_COLUMN_NAME);
         model.addColumn(REVIEW_COLUMN_NAME);
 
-        for (DbxEntry.File dbxEntry : entries) {
-            dlm.addElement(new DbxEntryRevision(dbxEntry));
-            model.addRow(new Object[]{dbxEntry.rev, dbxEntry.lastModified, dbxEntry.humanSize, REVIEW_BUTTON_LABEL});
+        if (entries != null && entries.size() > 0) {
+            for (DbxEntry.File dbxEntry : entries) {
+                dlm.addElement(new DbxEntryRevision(dbxEntry));
+                model.addRow(new Object[]{dbxEntry.rev, dbxEntry.lastModified, dbxEntry.humanSize, REVIEW_BUTTON_LABEL});
+            }
         }
 
         Action showVersion = new AbstractAction() {

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/DropboxRevisionsTopComponent.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/DropboxRevisionsTopComponent.java
@@ -178,10 +178,9 @@ public final class DropboxRevisionsTopComponent extends TopComponent {
             JTable table = (JTable) evt.getSource();
             int row = table.rowAtPoint(point);
             // Finding revision using information from the clicked row
-            Object revision = table.getValueAt(row, REVISION_COLUMN);
-            if (revision != null) {
-                String revisionNumber = revision.toString();
-                loadRevision(revisionNumber);
+            Object revisionNumber = table.getValueAt(row, REVISION_COLUMN);
+            if (revisionNumber != null) {
+                loadRevision(revisionNumber.toString());
             }
         }
     }//GEN-LAST:event_jTable1MousePressed

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/ConnectDropbox.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/ConnectDropbox.java
@@ -39,12 +39,12 @@ import org.openide.util.NbBundle.Messages;
 @Messages("CTL_ConnectDropbox=Connect to Dropbox")
 public final class ConnectDropbox implements ActionListener {
     
-    private static final String PROPETIES = "dropbox.properties";
+    private static final String PROPERTIES = "dropbox.properties";
     
     private static final String APP_KEY = PropertyService.
-            readProperties(PROPETIES).getProperty("dropbox.appKey");
+            readProperties(PROPERTIES).getProperty("dropbox.appKey");
     private static final String APP_SECRET = PropertyService.
-            readProperties(PROPETIES).getProperty("dropbox.appSecret");
+            readProperties(PROPERTIES).getProperty("dropbox.appSecret");
     
     private static final ApplicationLogger LOGGER = new ApplicationLogger("Dropbox");
 

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/DisconnectDropbox.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/DisconnectDropbox.java
@@ -1,5 +1,5 @@
 /* 
- * Copyright (c) 2015 Sebastian Brudzinski
+ * Copyright (c) 2016 Sebastian Brudzinski
  * 
  * See the file LICENSE for copying permission.
  */

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/DisconnectDropbox.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/DisconnectDropbox.java
@@ -62,8 +62,8 @@ public final class DisconnectDropbox implements ActionListener {
 
             } catch (DbxException ex) {
                 JOptionPane.showMessageDialog(null,
-                        "Invalid access token! Open LaTeX Studio has NOT been connected with Dropbox.\n Please try again and provide correct access token.",
-                        "Invalid token",
+                        "There is a problem with the Internet Connection\n Please, check your connection and try again.",
+                        "Unable to connect",
                         JOptionPane.ERROR_MESSAGE);
             }
         } else {

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/DisconnectDropbox.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/DisconnectDropbox.java
@@ -12,6 +12,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import javax.swing.JOptionPane;
 import latexstudio.editor.ApplicationLogger;
+import latexstudio.editor.DropboxRevisionsTopComponent;
+import latexstudio.editor.TopComponentFactory;
 import latexstudio.editor.settings.ApplicationSettings;
 import latexstudio.editor.settings.SettingsService;
 import latexstudio.editor.util.PropertyService;
@@ -30,45 +32,50 @@ import org.openide.util.NbBundle.Messages;
 @ActionReference(path = "Menu/Remote", position = 3508)
 @Messages("CTL_DisconnectDropbox=Disconnect from Dropbox")
 public final class DisconnectDropbox implements ActionListener {
-    
+
     private static final String PROPETIES = "dropbox.properties";
-    
+
     private static final String APP_KEY = PropertyService.
             readProperties(PROPETIES).getProperty("dropbox.appKey");
     private static final String APP_SECRET = PropertyService.
             readProperties(PROPETIES).getProperty("dropbox.appSecret");
-    
+
+    private final DropboxRevisionsTopComponent drtc = new TopComponentFactory<DropboxRevisionsTopComponent>()
+            .getTopComponent(DropboxRevisionsTopComponent.class.getSimpleName());
+
     private static final ApplicationLogger LOGGER = new ApplicationLogger("Dropbox");
 
     @Override
     public void actionPerformed(ActionEvent e) {
         DbxAppInfo appInfo = null;
         DbxClient client = DbxUtil.getDbxClient();
-        
+
         if (client == null) {
             return;
         }
-        
+
         String userToken = client.getAccessToken();
-        
+
         if (userToken != null && !userToken.isEmpty()) {
             try {
-                
+
                 client.disableAccessToken();
-                
+
+                drtc.updateRevisionsList(null);
+                drtc.close();
+
                 ApplicationSettings appSettings = SettingsService.loadApplicationSettings();
                 appSettings.setDropboxToken("");
                 SettingsService.saveApplicationSettings(appSettings);
                 LOGGER.log("Successfully disconnected from Dropbox account.");
-                
+
             } catch (DbxException ex) {
                 JOptionPane.showMessageDialog(null,
                         "Invalid access token! Open LaTeX Studio has NOT been connected with Dropbox.\n Please try again and provide correct access token.",
                         "Invalid token",
                         JOptionPane.ERROR_MESSAGE);
             }
-        }
-        else {
+        } else {
             LOGGER.log("Dropbox account already disconnected.");
         }
     }

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/DisconnectDropbox.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/DisconnectDropbox.java
@@ -5,7 +5,6 @@
  */
 package latexstudio.editor.remote;
 
-import com.dropbox.core.DbxAppInfo;
 import com.dropbox.core.DbxClient;
 import com.dropbox.core.DbxException;
 import java.awt.event.ActionEvent;
@@ -16,7 +15,6 @@ import latexstudio.editor.DropboxRevisionsTopComponent;
 import latexstudio.editor.TopComponentFactory;
 import latexstudio.editor.settings.ApplicationSettings;
 import latexstudio.editor.settings.SettingsService;
-import latexstudio.editor.util.PropertyService;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionRegistration;
@@ -33,13 +31,6 @@ import org.openide.util.NbBundle.Messages;
 @Messages("CTL_DisconnectDropbox=Disconnect from Dropbox")
 public final class DisconnectDropbox implements ActionListener {
 
-    private static final String PROPERTIES = "dropbox.properties";
-
-    private static final String APP_KEY = PropertyService.
-            readProperties(PROPERTIES).getProperty("dropbox.appKey");
-    private static final String APP_SECRET = PropertyService.
-            readProperties(PROPERTIES).getProperty("dropbox.appSecret");
-
     private final DropboxRevisionsTopComponent drtc = new TopComponentFactory<DropboxRevisionsTopComponent>()
             .getTopComponent(DropboxRevisionsTopComponent.class.getSimpleName());
 
@@ -47,10 +38,10 @@ public final class DisconnectDropbox implements ActionListener {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        DbxAppInfo appInfo = null;
         DbxClient client = DbxUtil.getDbxClient();
 
         if (client == null) {
+            LOGGER.log("Dropbox account already disconnected.");
             return;
         }
 

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/DisconnectDropbox.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/DisconnectDropbox.java
@@ -33,12 +33,12 @@ import org.openide.util.NbBundle.Messages;
 @Messages("CTL_DisconnectDropbox=Disconnect from Dropbox")
 public final class DisconnectDropbox implements ActionListener {
 
-    private static final String PROPETIES = "dropbox.properties";
+    private static final String PROPERTIES = "dropbox.properties";
 
     private static final String APP_KEY = PropertyService.
-            readProperties(PROPETIES).getProperty("dropbox.appKey");
+            readProperties(PROPERTIES).getProperty("dropbox.appKey");
     private static final String APP_SECRET = PropertyService.
-            readProperties(PROPETIES).getProperty("dropbox.appSecret");
+            readProperties(PROPERTIES).getProperty("dropbox.appSecret");
 
     private final DropboxRevisionsTopComponent drtc = new TopComponentFactory<DropboxRevisionsTopComponent>()
             .getTopComponent(DropboxRevisionsTopComponent.class.getSimpleName());

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/DisconnectDropbox.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/DisconnectDropbox.java
@@ -61,10 +61,7 @@ public final class DisconnectDropbox implements ActionListener {
                 LOGGER.log("Successfully disconnected from Dropbox account.");
 
             } catch (DbxException ex) {
-                JOptionPane.showMessageDialog(null,
-                        "There is a problem with the Internet Connection\n Please, check your connection and try again.",
-                        "Unable to connect",
-                        JOptionPane.ERROR_MESSAGE);
+                DbxUtil.showDbxAccessDeniedPrompt();
             }
         } else {
             LOGGER.log("Dropbox account already disconnected.");

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/DisconnectDropbox.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/DisconnectDropbox.java
@@ -1,0 +1,75 @@
+/* 
+ * Copyright (c) 2015 Sebastian Brudzinski
+ * 
+ * See the file LICENSE for copying permission.
+ */
+package latexstudio.editor.remote;
+
+import com.dropbox.core.DbxAppInfo;
+import com.dropbox.core.DbxClient;
+import com.dropbox.core.DbxException;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import javax.swing.JOptionPane;
+import latexstudio.editor.ApplicationLogger;
+import latexstudio.editor.settings.ApplicationSettings;
+import latexstudio.editor.settings.SettingsService;
+import latexstudio.editor.util.PropertyService;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionRegistration;
+import org.openide.util.NbBundle.Messages;
+
+@ActionID(
+        category = "Remote",
+        id = "latexstudio.editor.remote.DisconnectDropbox"
+)
+@ActionRegistration(
+        displayName = "#CTL_DisconnectDropbox"
+)
+@ActionReference(path = "Menu/Remote", position = 3508)
+@Messages("CTL_DisconnectDropbox=Disconnect from Dropbox")
+public final class DisconnectDropbox implements ActionListener {
+    
+    private static final String PROPETIES = "dropbox.properties";
+    
+    private static final String APP_KEY = PropertyService.
+            readProperties(PROPETIES).getProperty("dropbox.appKey");
+    private static final String APP_SECRET = PropertyService.
+            readProperties(PROPETIES).getProperty("dropbox.appSecret");
+    
+    private static final ApplicationLogger LOGGER = new ApplicationLogger("Dropbox");
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        DbxAppInfo appInfo = null;
+        DbxClient client = DbxUtil.getDbxClient();
+        
+        if (client == null) {
+            return;
+        }
+        
+        String userToken = client.getAccessToken();
+        
+        if (userToken != null && !userToken.isEmpty()) {
+            try {
+                
+                client.disableAccessToken();
+                
+                ApplicationSettings appSettings = SettingsService.loadApplicationSettings();
+                appSettings.setDropboxToken("");
+                SettingsService.saveApplicationSettings(appSettings);
+                LOGGER.log("Successfully disconnected from Dropbox account.");
+                
+            } catch (DbxException ex) {
+                JOptionPane.showMessageDialog(null,
+                        "Invalid access token! Open LaTeX Studio has NOT been connected with Dropbox.\n Please try again and provide correct access token.",
+                        "Invalid token",
+                        JOptionPane.ERROR_MESSAGE);
+            }
+        }
+        else {
+            LOGGER.log("Dropbox account already disconnected.");
+        }
+    }
+}

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/UploadToDropbox.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/UploadToDropbox.java
@@ -33,7 +33,7 @@ import org.openide.util.NbBundle.Messages;
 @ActionRegistration(
         displayName = "#CTL_UploadToDropbox"
 )
-@ActionReference(path = "Menu/Remote", position = 3433)
+@ActionReference(path = "Menu/Remote", position = 3433, separatorAfter = 3483)
 @Messages("CTL_UploadToDropbox=Upload to Dropbox")
 public final class UploadToDropbox implements ActionListener {
 


### PR DESCRIPTION
Issue #70 100%.
Tests finished. Apparently everything is working fine.
I created a **Disconnect** Menu Item which executes the following actions:
- Remove the access token from appSettings;
- Disable the Access Token;
- Clear Dropbox Revisions List and close its windows.

In addition to that, `DropboxRevisionsTopComponent.updateRevisionsList()` method was updated to accept `null` in order to clear the revisions list.

Finally, a typo correction was made in `OpenLaTeXStudio/EditorModule/src/latexstudio/editor/remote/ConnectDropbox.java` by replacing `PROPETIES` to `PROPERTIES`.