### PR TITLE
Issue#71: Add keyboard shortcut for saving file

### DIFF
--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/EditorTopComponent.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/EditorTopComponent.java
@@ -63,7 +63,6 @@ public final class EditorTopComponent extends TopComponent {
     private String latexPath;
 
     private static final int AUTO_COMPLETE_DELAY = 700;
-
     public EditorTopComponent() {
         initComponents();
         setName(Bundle.CTL_EditorTopComponent());
@@ -132,7 +131,7 @@ public final class EditorTopComponent extends TopComponent {
     }//GEN-LAST:event_rSyntaxTextAreaKeyReleased
 
     private void rSyntaxTextAreaKeyTyped(java.awt.event.KeyEvent evt) {//GEN-FIRST:event_rSyntaxTextAreaKeyTyped
-        if (currentFile == null) return;
+        if (currentFile == null || evt.isControlDown()) return;
         setDisplayName(currentFile.getName() + '*');
     }//GEN-LAST:event_rSyntaxTextAreaKeyTyped
 

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/menu/SaveFile.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/menu/SaveFile.java
@@ -30,7 +30,8 @@ import org.openide.util.NbBundle.Messages;
 )
 @ActionReferences({
     @ActionReference(path = "Menu/File", position = 1300),
-    @ActionReference(path = "Toolbars/File", position = 2222)
+    @ActionReference(path = "Toolbars/File", position = 2222),
+    @ActionReference(path = "Shortcuts", name = "D-S")
 })
 @Messages("CTL_SaveFile=Save")
 public final class SaveFile implements ActionListener {


### PR DESCRIPTION
Added ctrl-s keyboard shortcut for saving file.
Ignore keyboard input in editortopcomponent when cntrl is down so that * is not shown in file name after we press cntrl+s.