### PR TITLE
 Issue#67 Make auto-complete list display interval configurable

### DIFF
--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/Bundle.properties
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/Bundle.properties
@@ -18,3 +18,7 @@ DropboxRevisionsTopComponent.jTable1.columnModel.title2=File size
 DropboxRevisionsTopComponent.jTable1.columnModel.title1=Modified
 PDFViewerTopComponent.jLabel2.text=of 1
 DropboxRevisionsTopComponent.jTable1.columnModel.title3_1=Review
+LaTeXSettingsPanel.jLabel1.text=Auto complete popup delay
+LaTeXSettingsPanel.jLabel2.text=ms
+LaTeXSettingsPanel.jFormattedTextField1.text=750
+LaTeXSettingsPanel.jFormattedTextField1.text_1=9999

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/EditorTopComponent.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/EditorTopComponent.java
@@ -59,7 +59,6 @@ public final class EditorTopComponent extends TopComponent {
     private File currentFile;
     private DbxState dbxState;
 
-    private static final String AUTO_COMPLETE_DELAY_PROPERTY = "auto.complete.delay";
     private AutoCompletion autoCompletion = null;
     public EditorTopComponent() {
         initComponents();
@@ -72,7 +71,7 @@ public final class EditorTopComponent extends TopComponent {
         ApplicationSettings.INSTANCE.addPropertyChangeListener(new PropertyChangeListener() {
             @Override
             public void propertyChange(PropertyChangeEvent evt) {
-                if(evt.getPropertyName().equals(AUTO_COMPLETE_DELAY_PROPERTY)&&autoCompletion!=null){
+                if(evt.getPropertyName().equals(ApplicationSettings.AUTOCOMPLETE_DELAY)&&autoCompletion!=null){
                     autoCompletion.setAutoActivationDelay((Integer)evt.getNewValue());
                 }
             }

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/EditorTopComponent.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/EditorTopComponent.java
@@ -306,3 +306,4 @@ public final class EditorTopComponent extends TopComponent {
         return provider;
     }
 }
+

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/EditorTopComponent.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/EditorTopComponent.java
@@ -5,6 +5,8 @@
  */
 package latexstudio.editor;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -13,6 +15,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import javax.swing.text.BadLocationException;
 import latexstudio.editor.remote.DbxState;
+import latexstudio.editor.settings.ApplicationSettings;
 import latexstudio.editor.util.ApplicationUtils;
 import org.apache.commons.io.IOUtils;
 import org.fife.ui.autocomplete.AutoCompletion;
@@ -56,7 +59,8 @@ public final class EditorTopComponent extends TopComponent {
     private File currentFile;
     private DbxState dbxState;
 
-    private static final int AUTO_COMPLETE_DELAY = 700;
+    private static final String AUTO_COMPLETE_DELAY_PROPERTY = "auto.complete.delay";
+    private AutoCompletion autoCompletion = null;
     public EditorTopComponent() {
         initComponents();
         setName(Bundle.CTL_EditorTopComponent());
@@ -64,6 +68,15 @@ public final class EditorTopComponent extends TopComponent {
         setToolTipText(Bundle.HINT_EditorTopComponent());
         putClientProperty(TopComponent.PROP_CLOSING_DISABLED, Boolean.TRUE);
         putClientProperty(TopComponent.PROP_UNDOCKING_DISABLED, Boolean.TRUE);
+        
+        ApplicationSettings.INSTANCE.addPropertyChangeListener(new PropertyChangeListener() {
+            @Override
+            public void propertyChange(PropertyChangeEvent evt) {
+                if(evt.getPropertyName().equals(AUTO_COMPLETE_DELAY_PROPERTY)&&autoCompletion!=null){
+                    autoCompletion.setAutoActivationDelay((Integer)evt.getNewValue());
+                }
+            }
+        });
 
     }
 
@@ -127,11 +140,11 @@ public final class EditorTopComponent extends TopComponent {
     public void componentOpened() {
         ApplicationUtils.deleteTempFiles();
         CompletionProvider provider = createCompletionProvider();
-        AutoCompletion ac = new AutoCompletion(provider);
-        ac.setAutoActivationDelay(AUTO_COMPLETE_DELAY);
-        ac.setAutoActivationEnabled(true);
-        ac.setAutoCompleteEnabled(true);
-        ac.install(rSyntaxTextArea);
+        autoCompletion = new AutoCompletion(provider);
+        autoCompletion.setAutoActivationDelay(ApplicationSettings.INSTANCE.getAutoCompleteDelay());
+        autoCompletion.setAutoActivationEnabled(true);
+        autoCompletion.setAutoCompleteEnabled(true);
+        autoCompletion.install(rSyntaxTextArea);
 
         InputStream is = null;
         try {

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/LaTeXSettingsPanel.form
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/LaTeXSettingsPanel.form
@@ -16,9 +16,19 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="0" attributes="0">
+          <Group type="102" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="jPanel1" max="32767" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="jPanel1" alignment="0" max="32767" attributes="0"/>
+                  <Group type="102" alignment="0" attributes="0">
+                      <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="jFormattedTextField1" min="-2" pref="50" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                  </Group>
+              </Group>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
@@ -28,7 +38,13 @@
           <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Component id="jPanel1" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="32767" attributes="0"/>
+              <EmptySpace type="separate" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="jLabel1" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="jLabel2" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="jFormattedTextField1" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace pref="35" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -59,7 +75,7 @@
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="102" alignment="0" attributes="0">
                   <EmptySpace max="-2" attributes="0"/>
-                  <Component id="jTextField1" pref="270" max="32767" attributes="0"/>
+                  <Component id="jTextField1" pref="451" max="32767" attributes="0"/>
                   <EmptySpace type="separate" max="-2" attributes="0"/>
                   <Component id="jButton1" min="-2" pref="120" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
@@ -99,5 +115,29 @@
         </Component>
       </SubComponents>
     </Container>
+    <Component class="javax.swing.JLabel" name="jLabel1">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="latexstudio/editor/Bundle.properties" key="LaTeXSettingsPanel.jLabel1.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JLabel" name="jLabel2">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="latexstudio/editor/Bundle.properties" key="LaTeXSettingsPanel.jLabel2.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JFormattedTextField" name="jFormattedTextField1">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="latexstudio/editor/Bundle.properties" key="LaTeXSettingsPanel.jFormattedTextField1.text_1" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jFormattedTextField1ActionPerformed"/>
+      </Events>
+    </Component>
   </SubComponents>
 </Form>

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/LaTeXSettingsPanel.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/LaTeXSettingsPanel.java
@@ -20,8 +20,6 @@ import org.openide.util.Exceptions;
 final class LaTeXSettingsPanel extends javax.swing.JPanel {
 
     private final LaTeXSettingsOptionsPanelController controller;
-    public static final String KEY_AUTOCOMPLETE_DELAY = "auto_complete_delay";
-    public static final int DEFAULT_AUTOCOMPLETE_DELAY_MS = 700;
             
     LaTeXSettingsPanel(LaTeXSettingsOptionsPanelController controller) {
         this.controller = controller;

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/LaTeXSettingsPanel.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/LaTeXSettingsPanel.java
@@ -6,7 +6,10 @@
 package latexstudio.editor;
 
 import java.io.File;
+import java.text.NumberFormat;
 import javax.swing.JOptionPane;
+import javax.swing.text.DefaultFormatterFactory;
+import javax.swing.text.NumberFormatter;
 import latexstudio.editor.files.FileChooserService;
 import latexstudio.editor.settings.ApplicationSettings;
 import latexstudio.editor.util.ApplicationUtils;
@@ -15,11 +18,15 @@ import org.openide.util.NbPreferences;
 final class LaTeXSettingsPanel extends javax.swing.JPanel {
 
     private final LaTeXSettingsOptionsPanelController controller;
-
+    public static final String KEY_AUTOCOMPLETE_DELAY = "auto_complete_delay";
+    public static final int DEFAULT_AUTOCOMPLETE_DELAY_MS = 700;
+    private ApplicationLogger logger = new ApplicationLogger("LatexSettingsPanel");
+            
     LaTeXSettingsPanel(LaTeXSettingsOptionsPanelController controller) {
         this.controller = controller;
         initComponents();
         // TODO listen to changes in form fields and call controller.changed()
+        componentOpened();
     }
 
     /**
@@ -33,6 +40,9 @@ final class LaTeXSettingsPanel extends javax.swing.JPanel {
         jPanel1 = new javax.swing.JPanel();
         jTextField1 = new javax.swing.JTextField();
         jButton1 = new javax.swing.JButton();
+        jLabel1 = new javax.swing.JLabel();
+        jLabel2 = new javax.swing.JLabel();
+        jFormattedTextField1 = new javax.swing.JFormattedTextField();
 
         jPanel1.setBorder(javax.swing.BorderFactory.createTitledBorder(org.openide.util.NbBundle.getMessage(LaTeXSettingsPanel.class, "LaTeXSettingsPanel.jPanel1.border.title"))); // NOI18N
         jPanel1.setToolTipText(org.openide.util.NbBundle.getMessage(LaTeXSettingsPanel.class, "LaTeXSettingsPanel.toolTipText")); // NOI18N
@@ -53,7 +63,7 @@ final class LaTeXSettingsPanel extends javax.swing.JPanel {
             jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(jPanel1Layout.createSequentialGroup()
                 .addContainerGap()
-                .addComponent(jTextField1, javax.swing.GroupLayout.DEFAULT_SIZE, 270, Short.MAX_VALUE)
+                .addComponent(jTextField1, javax.swing.GroupLayout.DEFAULT_SIZE, 451, Short.MAX_VALUE)
                 .addGap(18, 18, 18)
                 .addComponent(jButton1, javax.swing.GroupLayout.PREFERRED_SIZE, 120, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addContainerGap())
@@ -68,13 +78,32 @@ final class LaTeXSettingsPanel extends javax.swing.JPanel {
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
+        org.openide.awt.Mnemonics.setLocalizedText(jLabel1, org.openide.util.NbBundle.getMessage(LaTeXSettingsPanel.class, "LaTeXSettingsPanel.jLabel1.text")); // NOI18N
+
+        org.openide.awt.Mnemonics.setLocalizedText(jLabel2, org.openide.util.NbBundle.getMessage(LaTeXSettingsPanel.class, "LaTeXSettingsPanel.jLabel2.text")); // NOI18N
+
+        jFormattedTextField1.setText(org.openide.util.NbBundle.getMessage(LaTeXSettingsPanel.class, "LaTeXSettingsPanel.jFormattedTextField1.text_1")); // NOI18N
+        jFormattedTextField1.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jFormattedTextField1ActionPerformed(evt);
+            }
+        });
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
-                .addComponent(jPanel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(jPanel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addGroup(layout.createSequentialGroup()
+                        .addComponent(jLabel1)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(jFormattedTextField1, javax.swing.GroupLayout.PREFERRED_SIZE, 50, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(jLabel2)
+                        .addGap(0, 0, Short.MAX_VALUE)))
                 .addContainerGap())
         );
         layout.setVerticalGroup(
@@ -82,12 +111,28 @@ final class LaTeXSettingsPanel extends javax.swing.JPanel {
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addComponent(jPanel1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addGap(18, 18, 18)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel1)
+                    .addComponent(jLabel2)
+                    .addComponent(jFormattedTextField1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addContainerGap(35, Short.MAX_VALUE))
         );
 
         jPanel1.getAccessibleContext().setAccessibleName(org.openide.util.NbBundle.getMessage(LaTeXSettingsPanel.class, "LaTeXSettingsPanel.jPanel1.AccessibleContext.accessibleName")); // NOI18N
     }// </editor-fold>//GEN-END:initComponents
+    
+    private void componentOpened(){
+        NumberFormat format = NumberFormat.getIntegerInstance();
+        format.setGroupingUsed(false);
+        NumberFormatter formatter = new NumberFormatter(format);
+        formatter.setValueClass(Integer.class);
+        formatter.setMinimum(0);
+        formatter.setMaximum(9999);
+        jFormattedTextField1.setFormatterFactory(new DefaultFormatterFactory(formatter));
 
+    }
+    
     private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton1ActionPerformed
         File directory = FileChooserService.getSelectedDirectory("Choose");
         File pdfLatexExe;
@@ -114,21 +159,40 @@ final class LaTeXSettingsPanel extends javax.swing.JPanel {
         }
     }//GEN-LAST:event_jButton1ActionPerformed
 
+    private void jFormattedTextField1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jFormattedTextField1ActionPerformed
+        // TODO add your handling code here:
+    }//GEN-LAST:event_jFormattedTextField1ActionPerformed
+
     void load() {
         jTextField1.setText( ApplicationSettings.INSTANCE.getLatexPath() );
+        jFormattedTextField1.setText(String.valueOf(NbPreferences.forModule(LaTeXSettingsPanel.class).getInt(LaTeXSettingsPanel.KEY_AUTOCOMPLETE_DELAY, DEFAULT_AUTOCOMPLETE_DELAY_MS)));
     }
-
+    
     void store() {
         ApplicationSettings.INSTANCE.setLatexPath( jTextField1.getText() );
         ApplicationSettings.INSTANCE.save();
+        
+        int autoCompleteDelay = DEFAULT_AUTOCOMPLETE_DELAY_MS;
+        
+        try{
+            autoCompleteDelay = Integer.parseInt(jFormattedTextField1.getText());
+        }catch(NumberFormatException ex){
+            autoCompleteDelay = DEFAULT_AUTOCOMPLETE_DELAY_MS;
+        }
+        
+        NbPreferences.forModule(LaTeXSettingsPanel.class).putInt(LaTeXSettingsPanel.KEY_AUTOCOMPLETE_DELAY, autoCompleteDelay);
     }
 
     boolean valid() {
         return true;
     }
+    
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton jButton1;
+    private javax.swing.JFormattedTextField jFormattedTextField1;
+    private javax.swing.JLabel jLabel1;
+    private javax.swing.JLabel jLabel2;
     private javax.swing.JPanel jPanel1;
     private javax.swing.JTextField jTextField1;
     // End of variables declaration//GEN-END:variables

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/settings/ApplicationSettings.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/settings/ApplicationSettings.java
@@ -5,6 +5,8 @@
  */
 package latexstudio.editor.settings;
 
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -19,10 +21,14 @@ import org.openide.util.Exceptions;
 public final class ApplicationSettings extends Properties {
     
     public static final ApplicationSettings INSTANCE = new ApplicationSettings();
-    
     private static final String DROPBOX_TOKEN   = "dropbox.token";
     private static final String USER_LASTDIR    = "user.lastdir";
     private static final String LATEX_PATH      = "latex.path";
+    private static final String AUTO_COMPLETE_DELAY = "auto.complete.delay";
+    
+    private static final int DEFAULT_AUTO_COMPLETE_DELAY = 700;
+    
+    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
     
     private ApplicationSettings() {
         load();
@@ -44,6 +50,14 @@ public final class ApplicationSettings extends Properties {
         }
     }
     
+    public void addPropertyChangeListener(PropertyChangeListener l) {
+        pcs.addPropertyChangeListener(l);
+    }
+
+    public void removePropertyChangeListener(PropertyChangeListener l) {
+        pcs.removePropertyChangeListener(l);
+    }
+    
     public void setDropboxToken(String token) {
         setProperty(DROPBOX_TOKEN, token);
     }
@@ -54,6 +68,7 @@ public final class ApplicationSettings extends Properties {
     
     public void setLatexPath(String path) {
         setProperty(LATEX_PATH, path);
+        
     }
     
     public String getLatexPath() {
@@ -66,5 +81,18 @@ public final class ApplicationSettings extends Properties {
     
     public String getUserLastDir() {
         return getProperty(USER_LASTDIR);
+    }
+    
+    public void setAutoCompleteDelay(int delay){
+        pcs.firePropertyChange(AUTO_COMPLETE_DELAY, getAutoCompleteDelay(), delay);
+        setProperty(AUTO_COMPLETE_DELAY, String.valueOf(delay));
+    }
+    
+    public int getAutoCompleteDelay(){
+        try{
+            return Integer.parseInt(getProperty(AUTO_COMPLETE_DELAY));
+        }catch(NumberFormatException ex){
+            return DEFAULT_AUTO_COMPLETE_DELAY;
+        }
     }
 }

--- a/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/settings/ApplicationSettings.java
+++ b/OpenLaTeXStudio/EditorModule/src/latexstudio/editor/settings/ApplicationSettings.java
@@ -24,7 +24,7 @@ public final class ApplicationSettings extends Properties {
     private static final String DROPBOX_TOKEN   = "dropbox.token";
     private static final String USER_LASTDIR    = "user.lastdir";
     private static final String LATEX_PATH      = "latex.path";
-    private static final String AUTO_COMPLETE_DELAY = "auto.complete.delay";
+    public static final String AUTOCOMPLETE_DELAY = "autocomplete.delay";
     
     private static final int DEFAULT_AUTO_COMPLETE_DELAY = 700;
     
@@ -84,13 +84,13 @@ public final class ApplicationSettings extends Properties {
     }
     
     public void setAutoCompleteDelay(int delay){
-        pcs.firePropertyChange(AUTO_COMPLETE_DELAY, getAutoCompleteDelay(), delay);
-        setProperty(AUTO_COMPLETE_DELAY, String.valueOf(delay));
+        pcs.firePropertyChange(AUTOCOMPLETE_DELAY, getAutoCompleteDelay(), delay);
+        setProperty(AUTOCOMPLETE_DELAY, String.valueOf(delay));
     }
     
     public int getAutoCompleteDelay(){
         try{
-            return Integer.parseInt(getProperty(AUTO_COMPLETE_DELAY));
+            return Integer.parseInt(getProperty(AUTOCOMPLETE_DELAY));
         }catch(NumberFormatException ex){
             return DEFAULT_AUTO_COMPLETE_DELAY;
         }


### PR DESCRIPTION
Add options in settings panel to change auto complete list display delay. Default is 700ms.

Change code to reflect change in auto complete delay settings change in editor.