### PR TITLE
Issue #107 ctrl-] for toggle comment

### DIFF
--- a/OpenLaTeXStudio/Editor/src/main/java/latexstudio/editor/toolbar/ToggleComment.java
+++ b/OpenLaTeXStudio/Editor/src/main/java/latexstudio/editor/toolbar/ToggleComment.java
@@ -30,7 +30,8 @@ import org.openide.windows.WindowManager;
 )
 @ActionReferences({
     @ActionReference(path = "Menu/Edit", position = 200),
-    @ActionReference(path = "Toolbars/Comment", position = 3333)
+    @ActionReference(path = "Toolbars/Comment", position = 3333),
+    @ActionReference(path = "Shortcuts", name = "D-CLOSE_BRACKET")
 })
 @Messages("CTL_ToggleComment=Toggle Comment")
 public final class ToggleComment implements ActionListener {


### PR DESCRIPTION
@aQaTL I encountered an issue when I set `Ctrl-/` as the shortcut. The line gets commented as expected, but an extra `/` gets inserted at the cursor position. This does not happen with `Ctrl-]`.